### PR TITLE
Updated th2-bom:4.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,15 @@ protobuf {
 
 ## Release notes
 
+### next
+
+* Update libs:
+  * bom: `4.10.0`
+    * Added suppressions:
+      * CVE-2025-25193 - This vulnerability does not affect us because this library don’t use netty for reading environment files.
+      * CVE-2025-24970 - this library doesn’t use SSL.
+* Updated owasp gradle plugin `12.1.0`
+
 ### 3.7.0
 
 * Removed th2 gradle plugin to avoid cycle dependency 

--- a/build.gradle
+++ b/build.gradle
@@ -208,16 +208,21 @@ dependencyLocking {
 dependencyCheck {
     formats = ['SARIF', 'JSON', 'HTML']
     failBuildOnCVSS = 5
+    suppressionFile = file("suppressions.xml")
 
     nvd {
         apiKey = project.findProperty("nvdApiKey") as String
         delay = Integer.valueOf(project.findProperty("nvdDelay") as String)
+        datafeedUrl = project.findProperty("nvdDatafeedUrl") as String
     }
 
     analyzers {
         assemblyEnabled = false
         nugetconfEnabled = false
         nodeEnabled = false
+        kev {
+            url = project.findProperty("analyzersKnownExploitedURL") as String
+        }
     }
 }
 

--- a/suppressions.xml
+++ b/suppressions.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- FIXME: find out approach to solve problem when any artifact with grpc word in name is marked as cpe:/a:grpc:grpc -->
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <suppress>
+        <notes><![CDATA[file name: netty-common-4.1.117.Final.jar]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.netty/netty-common@.*$</packageUrl>
+        <vulnerabilityName>CVE-2025-25193</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[file name: netty-handler-4.1.117.Final.jar]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.netty/netty-handler@.*$</packageUrl>
+        <vulnerabilityName>CVE-2025-24970</vulnerabilityName>
+    </suppress>
+</suppressions>


### PR DESCRIPTION
* Added suppressions:
  * CVE-2025-25193 - This vulnerability does not affect us because this library don’t use netty for reading environment files.
  * CVE-2025-24970 - this library doesn’t use SSL.
* Updated owasp gradle plugin `12.1.0`