### PR TITLE
Migrate to th2 gradle plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ protobuf {
   * bom: `4.11.0`
 * Updated plugins:
   * org.owasp.dependencycheck: `12.1.0`
+  * Migrate to th2 Gradle plugin `0.2.3`
 
 ### 3.7.0
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,4 @@
 plugins {
-    id 'java'
     id 'idea'
     id 'application'
     id 'java-library'

--- a/build.gradle
+++ b/build.gradle
@@ -1,28 +1,17 @@
-import com.github.jk1.license.filter.LicenseBundleNormalizer
-import com.github.jk1.license.render.JsonReportRenderer
-
 plugins {
     id 'java'
     id 'idea'
     id 'application'
     id 'java-library'
     id 'maven-publish'
-    id "io.github.gradle-nexus.publish-plugin" version "2.0.0"
     id 'signing'
     id 'org.jetbrains.kotlin.jvm' version "1.8.22"
     id 'com.github.johnrengelman.shadow' version '8.1.1'
-    id "org.owasp.dependencycheck" version "12.1.0"
-    id 'com.github.jk1.dependency-license-report' version "2.9"
-    id 'de.undercouch.download' version "5.6.0"
-    id "com.gorylenko.gradle-git-properties" version "2.4.2"
+    id 'com.exactpro.th2.gradle.publish' version '0.2.3'
 }
 
 group = 'com.exactpro.th2'
 version = release_version
-
-kotlin {
-    jvmToolchain(11)
-}
 
 repositories {
     mavenCentral()
@@ -35,10 +24,11 @@ repositories {
         url 'https://s01.oss.sonatype.org/content/repositories/releases/'
     }
 
-    configurations.configureEach {
-        resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
-        resolutionStrategy.cacheDynamicVersionsFor 0, 'seconds'
-    }
+}
+
+configurations.configureEach {
+    resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
+    resolutionStrategy.cacheDynamicVersionsFor 0, 'seconds'
 }
 
 dependencies {
@@ -66,18 +56,6 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter:5.12.0'
 }
 
-manifest {
-    attributes(
-            'Created-By': "${System.getProperty('java.version')} (${System.getProperty('java.vendor')})",
-            'Specification-Title': '',
-            'Specification-Vendor': 'Exactpro Systems LLC',
-            'Implementation-Title': project.archivesBaseName,
-            'Implementation-Vendor': 'Exactpro Systems LLC',
-            'Implementation-Vendor-Id': 'com.exactpro',
-            'Implementation-Version': project.version
-    )
-}
-
 test {
     useJUnitPlatform()
 }
@@ -91,154 +69,13 @@ javadoc {
     (options as StandardJavadocDocletOptions).addBooleanOption("html5", true)
 }
 
-// conditionals for publications
-tasks.withType(PublishToMavenRepository).configureEach {
-    onlyIf {
-        (repository == publishing.repositories.nexusRepository &&
-                project.hasProperty('nexus_user') &&
-                project.hasProperty('nexus_password') &&
-                project.hasProperty('nexus_url')) ||
-                (repository == publishing.repositories.sonatype &&
-                        project.hasProperty('sonatypeUsername') &&
-                        project.hasProperty('sonatypePassword'))
-    }
-}
-tasks.withType(Sign).configureEach {
-    onlyIf {
-        project.hasProperty('signingKey') &&
-                project.hasProperty('signingPassword')
-    }
-}
-// disable running task 'initializeSonatypeStagingRepository' on a gitlab
-tasks.configureEach { task ->
-    if (task.name == 'initializeSonatypeStagingRepository' &&
-            !(project.hasProperty('sonatypeUsername') && project.hasProperty('sonatypePassword'))
-    ) {
-        task.enabled = false
-    }
-}
-
-publishing {
-    publications {
-        mavenJava(MavenPublication) {
-            from(components.java)
-            pom {
-                name = rootProject.name
-                packaging = 'jar'
-                description = rootProject.description
-                url = vcs_url
-                scm {
-                    url = vcs_url
-                }
-                licenses {
-                    license {
-                        name = 'The Apache License, Version 2.0'
-                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-                    }
-                }
-                developers {
-                    developer {
-                        id = 'developer'
-                        name = 'developer'
-                        email = 'developer@exactpro.com'
-                    }
-                }
-                scm {
-                    url = vcs_url
-                }
-            }
-        }
-    }
-    repositories {
-        //Nexus repo to publish from gitlab
-        maven {
-            name = 'nexusRepository'
-            credentials {
-                username = project.findProperty('nexus_user')
-                password = project.findProperty('nexus_password')
-            }
-            url = project.findProperty('nexus_url')
-        }
-    }
-}
-
-nexusPublishing {
-    repositories {
-        sonatype {
-            nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
-            snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
-        }
-    }
-}
-
-signing {
-    String signingKey = findProperty("signingKey")
-    String signingPassword = findProperty("signingPassword")
-    useInMemoryPgpKeys(signingKey, signingPassword)
-    sign publishing.publications.mavenJava
-}
-
 application {
-    mainClassName = "com.exactpro.th2.service.generator.protoc.Main"
+    mainClass = "com.exactpro.th2.service.generator.protoc.Main"
 }
 
 shadowJar {
     mergeServiceFiles()
 
-    manifest {
-        attributes(
-                'Created-By': "${System.getProperty('java.version')} (${System.getProperty('java.vendor')})",
-                'Specification-Title': '',
-                'Specification-Vendor': 'Exactpro Systems LLC',
-                'Implementation-Title': project.archivesBaseName,
-                'Implementation-Vendor': 'Exactpro Systems LLC',
-                'Implementation-Vendor-Id': 'com.exactpro',
-                'Implementation-Version': project.version
-        )
-    }
-
     archiveFileName = project.name
-    destinationDirectory = "$buildDir/artifacts" as File
-}
-
-dependencyLocking {
-    lockAllConfigurations()
-}
-
-dependencyCheck {
-    formats = ['SARIF', 'JSON', 'HTML']
-    failBuildOnCVSS = 5
-    suppressionFile = file("suppressions.xml")
-
-    nvd {
-        apiKey = project.findProperty("nvdApiKey") as String
-        delay = Integer.valueOf(project.findProperty("nvdDelay") as String)
-    }
-
-    analyzers {
-        assemblyEnabled = false
-        nugetconfEnabled = false
-        nodeEnabled = false
-    }
-}
-
-licenseReport {
-    def licenseNormalizerBundlePath = "$buildDir/license-normalizer-bundle.json"
-
-    if (!file(licenseNormalizerBundlePath).exists()) {
-        download.run {
-            src 'https://raw.githubusercontent.com/th2-net/.github/main/license-compliance/gradle-license-report/license-normalizer-bundle.json'
-            dest "$buildDir/license-normalizer-bundle.json"
-            overwrite false
-        }
-    }
-
-    filters = [
-            new LicenseBundleNormalizer(licenseNormalizerBundlePath, false)
-    ]
-    renderers = [
-            new JsonReportRenderer('licenses.json', false),
-    ]
-    excludeOwnGroup = false
-    allowedLicensesFile = new URL("https://raw.githubusercontent.com/th2-net/.github/main/license-compliance/gradle-license-report/allowed-licenses.json")
+    destinationDirectory = project.layout.buildDirectory.dir("artifacts")
 }


### PR DESCRIPTION
This PR replaces the common plugins configuration with th2 Gradle plugin.
The th2 gRPC gradle plugin [knows about the service generator](https://github.com/th2-net/th2-gradle-plugin/blob/65f4b6a2ab5af9b728740447a0170f0437f1fddd/plugin/src/main/kotlin/com/exactpro/th2/gradle/GrpcTh2Plugin.kt#L99), however, is not used here. So, it should be okay.
Ideally, we could separate the Gradle plugin into separate artifacts (right now, they are published as a single JAR), but it is not critical at the moment - it does not have a dependency on the service generator and just knows its maven coordinates.

After migrating to th2 gradle plugin we can start using java 21 for builds